### PR TITLE
fix: ensure text visibility of output for dark mode

### DIFF
--- a/resources/views/tables/actions/html-2-media-table-action.blade.php
+++ b/resources/views/tables/actions/html-2-media-table-action.blade.php
@@ -1,5 +1,5 @@
 <div style="display: {{ isset($elementId) ? 'none' : 'block' }}">
-    <main id="print-smart-content-{{ $elementId ?? '' }}" wire:ignore>
+    <main id="print-smart-content-{{ $elementId ?? '' }}" style="color: black;" wire:ignore>
         {!! $content !!}
         <iframe style="display: none" id="print-smart-iframe-{{ $elementId ?? '' }}"></iframe>
     </main>


### PR DESCRIPTION
Added a CSS style to set the text color to black for the main div in the. This resolves the issue where text would turn white in dark mode while the  background remained white, ensuring proper text visibility.