### PR TITLE
added function to set a custom elementId for records that do not have…

### DIFF
--- a/src/Traits/HasHtml2MediaActionBase.php
+++ b/src/Traits/HasHtml2MediaActionBase.php
@@ -31,6 +31,7 @@ trait  HasHtml2MediaActionBase
     protected int|Closure $scale = 2;  // Separate variable for scale
     protected int|Closure|array $margin = 0; // Margin setting,
     protected bool|Closure $enableLinks = false; // Enable links PDF hyperlinks are automatically added ontop of all anchor tags.
+    protected null|string|Closure $elementId = null;
 
     public function enableLinks(bool|Closure $enableLinks = true): static
     {
@@ -211,7 +212,13 @@ trait  HasHtml2MediaActionBase
 
     public function getElementId(): string
     {
-        return $this->evaluate(fn($record) => $record->id.'-'.$this->name);
+        return $this->evaluate($this->elementId) ?? $this->evaluate(fn($record) => $record->id . '-' . $this->name);
+    }
+
+    public function elementId(string|Closure $elementId = null): static
+    {
+        $this->elementId = $elementId;
+        return $this;
     }
 
     public function savePdfAction(): Action


### PR DESCRIPTION
… uniq id k
This pull request includes enhancements to the `HasHtml2MediaActionBase` trait in the `src/Traits/HasHtml2MediaActionBase.php` file. The primary change is the addition of a new property and corresponding methods to manage an element ID.

Enhancements to `HasHtml2MediaActionBase` trait:

* Added a new property `elementId` to manage the element ID. (`[src/Traits/HasHtml2MediaActionBase.phpR34](diffhunk://#diff-bcf7aac2b719f734bb2b8570688affa3f6eb4e03526e37cc15404d3a91b1853aR34)`)
* Modified the `getElementId` method to use the new `elementId` property if set, otherwise defaulting to the existing behavior. (`[src/Traits/HasHtml2MediaActionBase.phpL214-R221](diffhunk://#diff-bcf7aac2b719f734bb2b8570688affa3f6eb4e03526e37cc15404d3a91b1853aL214-R221)`)
* Added a new method `elementId` to set the `elementId` property. (`[src/Traits/HasHtml2MediaActionBase.phpL214-R221](diffhunk://#diff-bcf7aac2b719f734bb2b8570688affa3f6eb4e03526e37cc15404d3a91b1853aL214-R221)`)ey