### PR TITLE
refactor: update margins to zero and remove view support from package

### DIFF
--- a/src/Html2MediaServiceProvider.php
+++ b/src/Html2MediaServiceProvider.php
@@ -14,7 +14,6 @@ class Html2MediaServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('html2media')
-            ->hasViews()
             ->hasAssets();
 
     }

--- a/src/Traits/HasHtml2MediaActionBase.php
+++ b/src/Traits/HasHtml2MediaActionBase.php
@@ -29,7 +29,7 @@ trait HasHtml2MediaActionBase
     protected bool|Closure $enableLinks = true;
     protected string|array|Closure $format = 'a4';
     protected string|Closure $orientation = 'portrait';
-    protected array|Closure $margins = ['top' => 20, 'right' => 20, 'bottom' => 20, 'left' => 20];
+    protected array|Closure $margins = ['top' => 0, 'right' => 0, 'bottom' => 0, 'left' => 0];
     protected string|Closure $overflow = 'paginate';
     protected bool|Closure $showPageNumbers = true;
     protected string|Closure $pageNumberPosition = 'bottom-center';


### PR DESCRIPTION
This pull request introduces two small changes: it updates the default margin values for the HTML-to-media conversion feature and removes view support from the package configuration.

* Configuration updates:
  * Changed default `margins` in the `HasHtml2MediaActionBase` trait to zero for all sides, which will affect output layout.
  * Removed `.hasViews()` from the package setup in `Html2MediaServiceProvider`, meaning the package no longer registers views by default.